### PR TITLE
Rename get_schur_complement and mumps_schur_complement

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -158,15 +158,15 @@ function mumps_det(A)
 end
 
 """
-    mumps_schur_complement!(mumps, schur_inds)
-    mumps_schur_complement_complement!(mumps, x)
+    mumps_schur!(mumps, schur_inds)
+    mumps_schur!(mumps, x)
 
 `schur_inds` is integer array of Schur indices.
 If `x` is sparse, Schur indices determined from populated rows of `x`
 
-See also: [`mumps_schur_complement`](@ref), [`get_schur_complement!`](@ref), [`get_schur_complement`](@ref)
+See also: [`mumps_schur`](@ref), [`get_schur!`](@ref), [`get_schur`](@ref)
 """
-function mumps_schur_complement!(mumps::Mumps, schur_inds::AbstractArray{Int, 1})
+function mumps_schur!(mumps::Mumps, schur_inds::AbstractArray{Int, 1})
   set_schur_centralized_by_column!(mumps, schur_inds)
   if mumps.job ∈ [1] # if analyzed only, factorize
     mumps.job = 2
@@ -175,25 +175,25 @@ function mumps_schur_complement!(mumps::Mumps, schur_inds::AbstractArray{Int, 1}
   end
   invoke_mumps!(mumps)
 end
-mumps_schur_complement!(mumps::Mumps, x::SparseMatrixCSC) =
-  mumps_schur_complement!(mumps, unique!(sort(x.rowval)))
-mumps_schur_complement!(mumps::Mumps, x::SparseVector) = mumps_schur_complement!(mumps, x.nzind)
+mumps_schur!(mumps::Mumps, x::SparseMatrixCSC) =
+  mumps_schur!(mumps, unique!(sort(x.rowval)))
+mumps_schur!(mumps::Mumps, x::SparseVector) = mumps_schur!(mumps, x.nzind)
 """
-    mumps_schur_complement(A,schur_inds) -> S
-    mumps_schur_complement(A,x) -> S
+    mumps_schur(A,schur_inds) -> S
+    mumps_schur(A,x) -> S
 
 `schur_inds` is integer array
 `x` is sparse, populated rows are Schur indices
 `S` is Schur complement matrix.
 
-See also: [`mumps_schur_complement!`](@ref)
+See also: [`mumps_schur!`](@ref)
 """
-function mumps_schur_complement(A::AbstractArray, x)
+function mumps_schur(A::AbstractArray, x)
   mumps = Mumps(A)
   suppress_display!(mumps)
   set_icntl!(mumps, 8, 0) # turn scaling off, not used with schur anyway (suppresses warning message with schur)
-  mumps_schur_complement!(mumps, x)
-  S = get_schur_complement(mumps)
+  mumps_schur!(mumps, x)
+  S = get_schur(mumps)
   finalize!(mumps)
   return S
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -338,32 +338,32 @@ function get_sol(mumps::Mumps{T}) where {T}
 end
 
 """
-    get_schur_complement!(S,mumps)
+    get_schur!(S,mumps)
 
 Retrieve Schur complement matrix from `mumps` into pre-allocated `S`
 
-See also: [`get_schur_complement`](@ref), [`mumps_schur!`](@ref), [`mumps_schur`](@ref)
+See also: [`get_schur`](@ref), [`mumps_schur!`](@ref), [`mumps_schur`](@ref)
 """
-function get_schur_complement!(S, mumps::Mumps)
+function get_schur!(S, mumps::Mumps)
   has_schur(mumps) || throw(MUMPSException("schur complement not yet allocated."))
-  get_schur_complement_unsafe!(S, mumps)
+  get_schur_unsafe!(S, mumps)
 end
-function get_schur_complement_unsafe!(S, mumps::Mumps)
+function get_schur_unsafe!(S, mumps::Mumps)
   for i ∈ LinearIndices(S)
     S[i] = unsafe_load(mumps.schur, i)
   end
   return S
 end
 """
-    get_schur_complement(mumps) -> S
+    get_schur(mumps) -> S
 
 Retrieve Schur complement matrix `S` from `mumps`
 
-See also: [`get_schur_complement!`](@ref), [`mumps_schur!`](@ref), [`mumps_schur`](@ref)
+See also: [`get_schur!`](@ref), [`mumps_schur!`](@ref), [`mumps_schur`](@ref)
 """
-function get_schur_complement(mumps::Mumps{T}) where {T}
+function get_schur(mumps::Mumps{T}) where {T}
   S = Array{T}(undef, mumps.size_schur, mumps.size_schur)
-  get_schur_complement!(S, mumps)
+  get_schur!(S, mumps)
 end
 
 """


### PR DESCRIPTION
I have issues with the documentation (#96) because a lot of docstrings have references to `get_schur` and `mumps_schur` but the functions are not defined...
I decided to rename these functions instead of updating all the docstrings.