### PR TITLE
Correction of undefined function

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -46,7 +46,7 @@ function mumps_solve!(x::AbstractArray, A::AbstractArray, rhs::AbstractArray; kw
 end
 
 function mumps_solve!(x::AbstractArray, mumps::Mumps, rhs::AbstractArray)
-  provide_rhs!(mumps, rhs)
+  associate_rhs!(mumps, rhs)
   if mumps.job ∈ [2, 4] # if already factored, just solve
   elseif mumps.job ∈ [1] # if analyzed only, factorize and solve
     mumps.job = 5

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -230,7 +230,7 @@ function mumps_select_inv! end
 function mumps_select_inv!(x::AbstractSparseArray, mumps::Mumps)
   set_icntl!(mumps, 30, 1)
   set_icntl!(mumps, 20, 3)
-  provide_rhs!(mumps, x)
+  associate_rhs!(mumps, x)
   if mumps.job ∈ [2, 4] # if already factored, just solve
     mumps.job = 3
   elseif mumps.job ∈ [1] # if analyzed only, factorize and solve
@@ -323,7 +323,7 @@ function LinearAlgebra.ldiv!(mumps::Mumps, y)
   else
     mumps.job = 2
   end
-  provide_rhs!(mumps, y)
+  associate_rhs!(mumps, y)
   mumps_solve!(y, mumps)
 end
 


### PR DESCRIPTION
In the issue #119 , the function `provide_rhs!` is called 3 times but it is never defined. I purpose to use `associate_rhs!` instead.

After this modification, I tried calling `LinearAlgebra.ldiv!` and it now works fine.