### PR TITLE
Release 1.4.1 -- Upgrade MUMPS_jll.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MUMPS"
 uuid = "55d2b088-9f4e-11e9-26c0-150b02ea6a46"
 authors = ["Dominique Orban <dominique.orban@gmail.com>","William R Sweeney <wrsweeney2@gmail.com>", "Alexis Montoison <alexis.montoison@polymtl.ca>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 MPI = "^0.20"
-MUMPS_jll = "= 5.6.1"
+MUMPS_jll = "= 5.6.2"
 
 julia = "^1.6"
 

--- a/src/MUMPS.jl
+++ b/src/MUMPS.jl
@@ -34,11 +34,10 @@ using MPI
 
 if haskey(ENV, "JULIA_MUMPS_LIBRARY_PATH")
   @info("Custom Installation")
-  const libsmumps = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libsmumps.$dlext")
-  const libdmumps = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libdmumps.$dlext")
-  const libcmumps = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libcmumps.$dlext")
-  const libzmumps = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libzmumps.$dlext")
-  const libmumps_common = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libmumps_common.$dlext")
+  const libsmumpspar = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libsmumps.$dlext")
+  const libdmumpspar = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libdmumps.$dlext")
+  const libcmumpspar = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libcmumps.$dlext")
+  const libzmumpspar = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libzmumps.$dlext")
   const MUMPS_INSTALLATION = "CUSTOM"
 else
   using MUMPS_jll

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -19,10 +19,10 @@ See also: [`invoke_mumps!`](@ref)
 function invoke_mumps_unsafe! end
 
 for (fname, lname, elty, subty) in (
-  ("smumps_c", libsmumps, Float32, Float32),
-  ("dmumps_c", libdmumps, Float64, Float64),
-  ("cmumps_c", libcmumps, ComplexF32, Float32),
-  ("zmumps_c", libzmumps, ComplexF64, Float64),
+  ("smumps_c", libsmumpspar, Float32, Float32),
+  ("dmumps_c", libdmumpspar, Float64, Float64),
+  ("cmumps_c", libcmumpspar, ComplexF32, Float32),
+  ("zmumps_c", libzmumpspar, ComplexF64, Float64),
 )
   @eval begin
     function invoke_mumps_unsafe!(mumps::Mumps{$elty, $subty})

--- a/src/mumps_struc.jl
+++ b/src/mumps_struc.jl
@@ -11,7 +11,7 @@ mutable struct MUMPSException <: Exception
 end
 const MUMPSValueDataType = Union{Float32, Float64, ComplexF32, ComplexF64}
 
-const MUMPS_VERSION = "5.5.1"
+const MUMPS_VERSION = "5.6.2"
 const MUMPS_VERSION_MAX_LEN = 30
 const DEFAULT_FORTRAN_COMMUNICATOR = -987654
 


### PR DESCRIPTION
I renamed the shared libraries in `MUMPS_jll.jl` when I compiled the release 5.6.2 such that they can coexist in the same environment than `MUMPS_seq_jll.jl`.
`MUMPS_seq_jll.jl` is a dependency of `Ipopt.jl` and the risk is quite high.

It also means that we can have both `MUMPS_seq_jll.jl` and `MUMPS_jll.jl` here now if we want.
Even  if `MUMPS_seq_jll.jl` is sequential, I compiled it with LBT and not OpenBLAS.
The speed-up could be nice for small linear systems.
