### PR TITLE
Optimize memory usage, allow mutating A and rhs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -123,10 +123,8 @@ Method                    | Description
 --------------------------|------------
 `finalize`                | Finalize a `Mumps` object. Must be done before calling `MPI.Finalize()`
 `associate_matrix!`       | Register a matrix with the `Mumps` object. This function makes it possible to define the data on the host only.
-`associate_matrix_unsafe!`| Register a matrix with the `Mumps` object. This function makes it possible to define the data on the host only. Passes MUMPS pointers to the arguments' data where possible.
 `factorize!`              | Factorize the matrix registered with the `Mumps` object.
 `associate_rhs!`          | Register right-hand sides with the `Mumps` object. This function makes it possible to define the data on the host only.
-`associate_rhs_unsafe!`   | Register right-hand sides with the `Mumps` object. This function makes it possible to define the data on the host only. Passes MUMPS pointers to the arguments' data where possible.
 `solve!`                  | Solve the linear system for the given right-hand side.
 `get_solution`            | Retrieve the solution from the `Mumps` object. This function makes it possible for the solution to be assembled on the host only.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -119,14 +119,16 @@ A `Mumps` object is destroyed by calling the `finalize()` method. Because
 `finalize` still issues MPI commands, it is important to call `finalize()`
 before calling `MPI.Finalize()`.
 
-Method             | Description
--------------------|------------
-`finalize`         | Finalize a `Mumps` object. Must be done before calling `MPI.Finalize()`
-`associate_matrix!`| Register a matrix with the `Mumps` object. This function makes it possible to define the data on the host only.
-`factorize!`       | Factorize the matrix registered with the `Mumps` object.
-`associate_rhs!`   | Register right-hand sides with the `Mumps` object. This function makes it possible to define the data on the host only.
-`solve!`           | Solve the linear system for the given right-hand side.
-`get_solution`     | Retrieve the solution from the `Mumps` object. This function makes it possible for the solution to be assembled on the host only.
+Method                    | Description
+--------------------------|------------
+`finalize`                | Finalize a `Mumps` object. Must be done before calling `MPI.Finalize()`
+`associate_matrix!`       | Register a matrix with the `Mumps` object. This function makes it possible to define the data on the host only.
+`associate_matrix_unsafe!`| Register a matrix with the `Mumps` object. This function makes it possible to define the data on the host only. Passes MUMPS pointers to the arguments' data where possible.
+`factorize!`              | Factorize the matrix registered with the `Mumps` object.
+`associate_rhs!`          | Register right-hand sides with the `Mumps` object. This function makes it possible to define the data on the host only.
+`associate_rhs_unsafe!`   | Register right-hand sides with the `Mumps` object. This function makes it possible to define the data on the host only. Passes MUMPS pointers to the arguments' data where possible.
+`solve!`                  | Solve the linear system for the given right-hand side.
+`get_solution`            | Retrieve the solution from the `Mumps` object. This function makes it possible for the solution to be assembled on the host only.
 
 ## Parallel Execution
 

--- a/src/exported_methods.jl
+++ b/src/exported_methods.jl
@@ -1,6 +1,6 @@
 export get_icntl, default_icntl, default_cntl32, default_cntl64
 
-export associate_matrix!, associate_matrix_unsafe!, associate_rhs!, associate_rhs_unsafe!, get_solution, solve!, solve, factorize!
+export associate_matrix!, associate_rhs!, get_solution, solve!, solve, factorize!
 
 export mumps_unsymmetric, mumps_definite, mumps_symmetric
 

--- a/src/exported_methods.jl
+++ b/src/exported_methods.jl
@@ -1,6 +1,6 @@
 export get_icntl, default_icntl, default_cntl32, default_cntl64
 
-export associate_matrix!, associate_rhs!, get_solution, solve!, solve, factorize!
+export associate_matrix!, associate_matrix_unsafe!, associate_rhs!, associate_rhs_unsafe!, get_solution, solve!, solve, factorize!
 
 export mumps_unsymmetric, mumps_definite, mumps_symmetric
 

--- a/src/mumps_struc.jl
+++ b/src/mumps_struc.jl
@@ -1,5 +1,5 @@
 # this file mirrors the relevant content of the "[sdcz]mumps_c.h" file of MUMPS
-# `gc_haven`, contains Julia references to protect the pointers passed to C from gargage collection.
+# `_*_gc_haven`, contains Julia references to protect the pointers passed to C from gargage collection.
 export Mumps, MUMPSException
 
 """
@@ -121,14 +121,26 @@ mutable struct Mumps{TC, TR}
   det::TC
   err::Int
 
-  _gc_haven::Array{Ref, 1}
+  # Individual _*_gc_haven Ref's for each variable, so that we can overwrite them to avoid
+  # accumulating Ref's to unused variables
+  _irn_gc_haven::Vector{MUMPS_INT}
+  _jcn_gc_haven::Vector{MUMPS_INT}
+  _a_gc_haven::Vector{TC}
+  _eltptr_gc_haven::Vector{MUMPS_INT}
+  _eltvar_gc_haven::Vector{MUMPS_INT}
+  _a_elt_gc_haven::Vector{TC}
+  _y_gc_haven::Vector{TC}
+  _rhs_sparse_gc_haven::Vector{TC}
+  _irhs_sparse_gc_haven::Vector{MUMPS_INT}
+  _irhs_ptr_gc_haven::Vector{MUMPS_INT}
+  _listvar_schur_ptr_gc_haven::Vector{MUMPS_INT}
+  _schur_gc_haven::Vector{TC}
   _finalized::Bool
 
   function Mumps{T}(sym::Integer, par::Integer, comm::Integer) where {T <: MUMPSValueDataType}
     !MPI.Initialized() ? throw(MUMPSException("Initialize MPI first")) : nothing
     mumps = new{T, real(T)}(sym, par, -1, comm)
     invoke_mumps_unsafe!(mumps)
-    mumps._gc_haven = Array{Ref, 1}(undef, 0)
     mumps._finalized = false
     finalizer(finalize!, mumps)
     return mumps

--- a/test/mumps_test.jl
+++ b/test/mumps_test.jl
@@ -16,11 +16,11 @@ MPI.Barrier(comm)
 
 mumps1_unsafe = Mumps{Float64}(mumps_definite, icntl, default_cntl32);
 A = sparse(Diagonal([1.0, 2.0, 3.0, 4.0]))
-associate_matrix_unsafe!(mumps1_unsafe, A)
+associate_matrix!(mumps1_unsafe, A; unsafe=true)
 factorize!(mumps1_unsafe);  # Analyze and factorize.
 rhs = [1.0, 4.0, 9.0, 16.0]
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps1_unsafe, rhs)
+associate_rhs!(mumps1_unsafe, rhs; unsafe=true)
 solve!(mumps1_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps1_unsafe)
@@ -49,11 +49,11 @@ MPI.Barrier(comm)
 
 mumps3_unsafe = Mumps{Float64}(mumps_unsymmetric, icntl, default_cntl32);
 A = sparse(random_matrix(Float64, [1, 2, 3, 4], 4, 4))
-associate_matrix_unsafe!(mumps3_unsafe, A)
+associate_matrix!(mumps3_unsafe, A; unsafe=true)
 factorize!(mumps3_unsafe);  # Analyze and factorize.
 rhs = [1.0, 4.0, 9.0, 16.0]
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps3_unsafe, rhs)
+associate_rhs!(mumps3_unsafe, rhs; unsafe=true)
 solve!(mumps3_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps3_unsafe)

--- a/test/mumps_test.jl
+++ b/test/mumps_test.jl
@@ -14,6 +14,20 @@ finalize(mumps1)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
 
+mumps1_unsafe = Mumps{Float64}(mumps_definite, icntl, default_cntl32);
+A = sparse(Diagonal([1.0, 2.0, 3.0, 4.0]))
+associate_matrix_unsafe!(mumps1_unsafe, A)
+factorize!(mumps1_unsafe);  # Analyze and factorize.
+rhs = [1.0, 4.0, 9.0, 16.0]
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps1_unsafe, rhs)
+solve!(mumps1_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps1_unsafe)
+finalize(mumps1_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
+
 mumps2 = Mumps{Float64}(mumps_symmetric, icntl, default_cntl64);
 A = random_matrix(Float64, [1, 2, 3, 4], 4, 4);
 A = sparse(A + A');
@@ -32,6 +46,20 @@ x = solve(mumps3, rhs);
 finalize(mumps3);
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1));
+
+mumps3_unsafe = Mumps{Float64}(mumps_unsymmetric, icntl, default_cntl32);
+A = sparse(random_matrix(Float64, [1, 2, 3, 4], 4, 4))
+associate_matrix_unsafe!(mumps3_unsafe, A)
+factorize!(mumps3_unsafe);  # Analyze and factorize.
+rhs = [1.0, 4.0, 9.0, 16.0]
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps3_unsafe, rhs)
+solve!(mumps3_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps3_unsafe)
+finalize(mumps3_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
 
 # Test for solving real div-grad system with single and multiple rhs.
 # Based on Lars Ruthotto's initial implementation.

--- a/test/mumps_test_complex.jl
+++ b/test/mumps_test_complex.jl
@@ -14,6 +14,20 @@ finalize(mumps1)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
 
+mumps1_unsafe = Mumps{ComplexF64}(mumps_definite, icntl, default_cntl32);
+A = sparse(Diagonal(Array{ComplexF64}([1.0, 2.0, 3.0, 4.0])))
+associate_matrix_unsafe!(mumps1_unsafe, A)
+factorize!(mumps1_unsafe);  # Analyze and factorize.
+rhs = Array{ComplexF64}([1.0, 4.0, 9.0, 16.0])
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps1_unsafe, rhs)
+solve!(mumps1_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps1_unsafe)
+finalize(mumps1_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
+
 mumps2 = Mumps{ComplexF64}(mumps_symmetric, icntl, default_cntl64)
 A = random_matrix(Float64, [1, 2, 3, 4], 4, 4);
 A = sparse(A + A');
@@ -32,6 +46,20 @@ x = solve(mumps3, rhs)
 finalize(mumps3)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
+
+mumps3_unsafe = Mumps{ComplexF64}(mumps_unsymmetric, icntl, default_cntl32);
+A = sparse(random_matrix(ComplexF64, [1, 2, 3, 4], 4, 4))
+associate_matrix_unsafe!(mumps3_unsafe, A)
+factorize!(mumps3_unsafe);  # Analyze and factorize.
+rhs = Array{ComplexF64}([1.0, 4.0, 9.0, 16.0])
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps3_unsafe, rhs)
+solve!(mumps3_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps3_unsafe)
+finalize(mumps3_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
 
 # Test convenience interface.
 

--- a/test/mumps_test_complex.jl
+++ b/test/mumps_test_complex.jl
@@ -16,11 +16,11 @@ MPI.Barrier(comm)
 
 mumps1_unsafe = Mumps{ComplexF64}(mumps_definite, icntl, default_cntl32);
 A = sparse(Diagonal(Array{ComplexF64}([1.0, 2.0, 3.0, 4.0])))
-associate_matrix_unsafe!(mumps1_unsafe, A)
+associate_matrix!(mumps1_unsafe, A; unsafe=true)
 factorize!(mumps1_unsafe);  # Analyze and factorize.
 rhs = Array{ComplexF64}([1.0, 4.0, 9.0, 16.0])
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps1_unsafe, rhs)
+associate_rhs!(mumps1_unsafe, rhs; unsafe=true)
 solve!(mumps1_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps1_unsafe)
@@ -49,11 +49,11 @@ MPI.Barrier(comm)
 
 mumps3_unsafe = Mumps{ComplexF64}(mumps_unsymmetric, icntl, default_cntl32);
 A = sparse(random_matrix(ComplexF64, [1, 2, 3, 4], 4, 4))
-associate_matrix_unsafe!(mumps3_unsafe, A)
+associate_matrix!(mumps3_unsafe, A; unsafe=true)
 factorize!(mumps3_unsafe);  # Analyze and factorize.
 rhs = Array{ComplexF64}([1.0, 4.0, 9.0, 16.0])
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps3_unsafe, rhs)
+associate_rhs!(mumps3_unsafe, rhs; unsafe=true)
 solve!(mumps3_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps3_unsafe)

--- a/test/mumps_test_float.jl
+++ b/test/mumps_test_float.jl
@@ -10,6 +10,20 @@ finalize(mumps1)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
 
+mumps1_unsafe = Mumps{Float32}(mumps_definite, icntl, default_cntl32);
+A = sparse(Diagonal(Array{Float32}([1.0, 2.0, 3.0, 4.0])))
+associate_matrix_unsafe!(mumps1_unsafe, A)
+factorize!(mumps1_unsafe);  # Analyze and factorize.
+rhs = Array{Float32}([1.0, 4.0, 9.0, 16.0])
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps1_unsafe, rhs)
+solve!(mumps1_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps1_unsafe)
+finalize(mumps1_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
+
 mumps2 = Mumps{Float32}(mumps_symmetric, icntl, default_cntl32)
 A = random_matrix(Float32, [1, 2, 3, 4], 4, 4);
 A = sparse(A + A');
@@ -28,6 +42,20 @@ x = solve(mumps3, rhs)
 finalize(mumps3)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
+
+mumps3_unsafe = Mumps{Float32}(mumps_unsymmetric, icntl, default_cntl32);
+A = sparse(random_matrix(Float32, [1, 2, 3, 4], 4, 4))
+associate_matrix_unsafe!(mumps3_unsafe, A)
+factorize!(mumps3_unsafe);  # Analyze and factorize.
+rhs = Array{Float32}([1.0, 4.0, 9.0, 16.0])
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps3_unsafe, rhs)
+solve!(mumps3_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps3_unsafe)
+finalize(mumps3_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
 
 # Test convenience interface.
 

--- a/test/mumps_test_float.jl
+++ b/test/mumps_test_float.jl
@@ -12,11 +12,11 @@ MPI.Barrier(comm)
 
 mumps1_unsafe = Mumps{Float32}(mumps_definite, icntl, default_cntl32);
 A = sparse(Diagonal(Array{Float32}([1.0, 2.0, 3.0, 4.0])))
-associate_matrix_unsafe!(mumps1_unsafe, A)
+associate_matrix!(mumps1_unsafe, A; unsafe=true)
 factorize!(mumps1_unsafe);  # Analyze and factorize.
 rhs = Array{Float32}([1.0, 4.0, 9.0, 16.0])
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps1_unsafe, rhs)
+associate_rhs!(mumps1_unsafe, rhs; unsafe=true)
 solve!(mumps1_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps1_unsafe)
@@ -45,11 +45,11 @@ MPI.Barrier(comm)
 
 mumps3_unsafe = Mumps{Float32}(mumps_unsymmetric, icntl, default_cntl32);
 A = sparse(random_matrix(Float32, [1, 2, 3, 4], 4, 4))
-associate_matrix_unsafe!(mumps3_unsafe, A)
+associate_matrix!(mumps3_unsafe, A; unsafe=true)
 factorize!(mumps3_unsafe);  # Analyze and factorize.
 rhs = Array{Float32}([1.0, 4.0, 9.0, 16.0])
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps3_unsafe, rhs)
+associate_rhs!(mumps3_unsafe, rhs; unsafe=true)
 solve!(mumps3_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps3_unsafe)

--- a/test/mumps_test_float_complex.jl
+++ b/test/mumps_test_float_complex.jl
@@ -16,11 +16,11 @@ MPI.Barrier(comm)
 
 mumps1_unsafe = Mumps{ComplexF32}(mumps_definite, icntl, default_cntl32);
 A = sparse(Diagonal(Array{ComplexF32}([1.0, 2.0, 3.0, 4.0])))
-associate_matrix_unsafe!(mumps1_unsafe, A)
+associate_matrix!(mumps1_unsafe, A; unsafe=true)
 factorize!(mumps1_unsafe);  # Analyze and factorize.
 rhs = Array{ComplexF32}([1.0, 4.0, 9.0, 16.0])
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps1_unsafe, rhs)
+associate_rhs!(mumps1_unsafe, rhs; unsafe=true)
 solve!(mumps1_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps1_unsafe)
@@ -49,11 +49,11 @@ MPI.Barrier(comm)
 
 mumps3_unsafe = Mumps{ComplexF32}(mumps_unsymmetric, icntl, default_cntl32);
 A = sparse(random_matrix(ComplexF32, [1, 2, 3, 4], 4, 4))
-associate_matrix_unsafe!(mumps3_unsafe, A)
+associate_matrix!(mumps3_unsafe, A; unsafe=true)
 factorize!(mumps3_unsafe);  # Analyze and factorize.
 rhs = Array{ComplexF32}([1.0, 4.0, 9.0, 16.0])
 orig_rhs = copy(rhs)
-associate_rhs_unsafe!(mumps3_unsafe, rhs)
+associate_rhs!(mumps3_unsafe, rhs; unsafe=true)
 solve!(mumps3_unsafe)
 x = similar(orig_rhs)
 get_sol!(x, mumps3_unsafe)

--- a/test/mumps_test_float_complex.jl
+++ b/test/mumps_test_float_complex.jl
@@ -14,6 +14,20 @@ finalize(mumps1)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
 
+mumps1_unsafe = Mumps{ComplexF32}(mumps_definite, icntl, default_cntl32);
+A = sparse(Diagonal(Array{ComplexF32}([1.0, 2.0, 3.0, 4.0])))
+associate_matrix_unsafe!(mumps1_unsafe, A)
+factorize!(mumps1_unsafe);  # Analyze and factorize.
+rhs = Array{ComplexF32}([1.0, 4.0, 9.0, 16.0])
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps1_unsafe, rhs)
+solve!(mumps1_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps1_unsafe)
+finalize(mumps1_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
+
 mumps2 = Mumps{ComplexF32}(mumps_unsymmetric, icntl, default_cntl32)
 A = random_matrix(Float64, [1, 2, 3, 4], 4, 4);
 A = sparse(A + A');
@@ -32,6 +46,20 @@ x = solve(mumps3, rhs)
 finalize(mumps3)
 MPI.Barrier(comm)
 @test(norm(A * x - rhs) <= tol * norm(rhs) * norm(A, 1))
+
+mumps3_unsafe = Mumps{ComplexF32}(mumps_unsymmetric, icntl, default_cntl32);
+A = sparse(random_matrix(ComplexF32, [1, 2, 3, 4], 4, 4))
+associate_matrix_unsafe!(mumps3_unsafe, A)
+factorize!(mumps3_unsafe);  # Analyze and factorize.
+rhs = Array{ComplexF32}([1.0, 4.0, 9.0, 16.0])
+orig_rhs = copy(rhs)
+associate_rhs_unsafe!(mumps3_unsafe, rhs)
+solve!(mumps3_unsafe)
+x = similar(orig_rhs)
+get_sol!(x, mumps3_unsafe)
+finalize(mumps3_unsafe)
+MPI.Barrier(comm)
+@test(norm(A * x - orig_rhs) <= tol * norm(orig_rhs) * norm(A, 1))
 
 # Test convenience interface.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Random
 using LinearAlgebra
 using MPI
 using MUMPS
+using MUMPS: get_sol!
 using SparseArrays
 
 Random.seed!(666)  # Random tests are diabolical


### PR DESCRIPTION
Replaces `_gc_haven::Vector{Ref}` with individual `_*_gc_haven` fields, so that only the current data is protected from garbage collection, and copies of old data are not stored. Previously copies were stored, so for example if the rhs was changed many times, copies of all the rhs vectors were stored, resulting in growing memory usage.

Provides `associate_matrix_unsafe!()` and `associate_rhs_unsafe!()` which (where possible) directly pass MUMPS pointers to the data in the matrix or rhs Julia object passed to the functions. Previously the matrix and rhs were always copied, which adds some inefficiency. This change also allows the matrix and rhs within MUMPS to be mutated by modifying the original Julia objects.

Fixes #136.