### PR TITLE
Update a variable bug and extend the Int type of size_schur from 32 to 64

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -439,7 +439,7 @@ function set_schur_centralized_by_column!(mumps::Mumps{T}, schur_inds::AbstractA
   schur = Array{T}(undef, mumps.size_schur^2)
   mumps.schur = pointer(schur)
   set_icntl!(mumps, 19, 3)
-  mumps._listvar_schur_gc_haven = listvar_schur
+  mumps._listvar_schur_ptr_gc_haven = listvar_schur
   mumps._schur_gc_haven = schur
   return mumps
 end

--- a/src/mumps_struc.jl
+++ b/src/mumps_struc.jl
@@ -101,7 +101,7 @@ mutable struct Mumps{TC, TR}
   pivnul_list::Ptr{MUMPS_INT}
   mapping::Ptr{MUMPS_INT}
 
-  size_schur::MUMPS_INT
+  size_schur::MUMPS_INT8
   listvar_schur::Ptr{MUMPS_INT}
   schur::Ptr{TC}
 


### PR DESCRIPTION
- Fix a variable name bug for Schur computation
- Extend the Int type of size_schur  from 32 to 64 to support larger Schur computation