### PR TITLE
Fix issue #154

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -107,9 +107,9 @@ set name of directory in which to store out-of-core files.
 function set_save_dir!(mumps, dir::String)
   length(dir) ≤ 255 ||
     throw(MUMPSException("directory name has $(length(dir)) characters, must be ≤ 255"))
-  i = length(dir + 1)
-  save_dir = mumps.save_dir
-  mumps.save_dir = (dir..., '\0', save_dir[(i + 2):end]...)
+  i, N = length(dir), length(mumps.save_dir)
+  # repeat avoids a type inference stack overflow, from the very long tuple
+  mumps.save_dir = (Cchar.(collect(dir))..., repeat([Cchar(0)],N-i)...)
   return mumps
 end
 
@@ -121,9 +121,8 @@ prefix for out-of-core files.
 function set_save_prefix!(mumps, prefix::String)
   length(prefix) ≤ 255 ||
     throw(MUMPSException("prefix name has $(length(prefix)) characters, must be ≤ 255"))
-  i = length(prefix + 1)
-  save_prefix = mumps.save_prefix
-  mumps.save_prefix = (prefix..., '\0', save_prefix[(i + 2):end]...)
+  i, N = length(prefix), length(mumps.save_prefix)
+  mumps.save_prefix = (Cchar.(collect(prefix))..., repeat([Cchar(0)],N-i)...)
   return mumps
 end
 

--- a/test/mumps_test_save.jl
+++ b/test/mumps_test_save.jl
@@ -1,0 +1,14 @@
+A = SparseArrays.sprand(10, 10, 0.4)
+S = A + A'
+mumps = Mumps{Float64}(mumps_symmetric, default_icntl, default_cntl64)
+associate_matrix!(mumps, S)
+MUMPS.set_job!(mumps, 1)
+MUMPS.invoke_mumps!(mumps)
+save_dir = mktempdir(;prefix="_mumps_test_save_")
+MUMPS.set_save_dir!(mumps, save_dir)
+MUMPS.set_job!(mumps, 7)
+MUMPS.invoke_mumps!(mumps)
+@test length(readdir(save_dir)) > 0
+MUMPS.set_job!(mumps, -3)
+MUMPS.invoke_mumps!(mumps)
+finalize(mumps)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,9 @@ end
 @testset "mixed: " begin
   include("mumps_test_mixed.jl")
 end
+@testset "save: " begin
+  include("mumps_test_save.jl")
+end
 
 MPI.Barrier(comm)
 MPI.Finalize()


### PR DESCRIPTION
Just fixing the indexing lead to an `InternalError` about stack overflow from type inference with very long tuples. As a workaround, I'm filling the remainder of `mumps.save_dir` with null characters (instead of writing a single terminating null character). Also added a simple test.