### PR TITLE
Remove finalizer to fix MPI crash at shutdown

### DIFF
--- a/src/mumps_struc.jl
+++ b/src/mumps_struc.jl
@@ -159,7 +159,6 @@ mutable struct Mumps{TC, TR}
     mumps = new{T, real(T)}(sym, par, -1, comm)
     invoke_mumps_unsafe!(mumps)
     mumps._finalized = false
-    finalizer(finalize!, mumps)
     return mumps
   end
 end


### PR DESCRIPTION
Fixes #183

MPI calls from Julia finalizers are unsafe because:
1. MPI is finalized during `atexit()` before Julia finalizers run, causing crashes
2. Non-deterministic finalization order across MPI ranks can cause deadlocks or cluster desync

This PR removes the finalizer registration entirely. Users who need cleanup should call `finalize!(mumps)` explicitly.

This is a minimal, safe fix - the `finalize!` function remains available for explicit use.