### PR TITLE
Add option to use MUMPS_seq_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MUMPS"
 uuid = "55d2b088-9f4e-11e9-26c0-150b02ea6a46"
-version = "1.6.0"
 authors = ["Dominique Orban <dominique.orban@gmail.com>", "William R Sweeney <wrsweeney2@gmail.com>", "Alexis Montoison <alexis.montoison@polymtl.ca>"]
+version = "1.6.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "MUMPS"
 uuid = "55d2b088-9f4e-11e9-26c0-150b02ea6a46"
-authors = ["Dominique Orban <dominique.orban@gmail.com>", "William R Sweeney <wrsweeney2@gmail.com>", "Alexis Montoison <alexis.montoison@polymtl.ca>"]
 version = "1.6.0"
+authors = ["Dominique Orban <dominique.orban@gmail.com>", "William R Sweeney <wrsweeney2@gmail.com>", "Alexis Montoison <alexis.montoison@polymtl.ca>"]
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MUMPS_jll = "ca64183c-ec4f-5579-95d5-17e128c21291"
+MUMPS_seq_jll = "d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
@@ -16,6 +17,7 @@ Libdl = "1.10"
 LinearAlgebra = "1.10"
 MPI = "0.20"
 MUMPS_jll = "= 5.8.2"
+MUMPS_seq_jll = "500.900.0"
 OpenBLAS32_jll = "0.3.23"
 SparseArrays = "1.10"
 julia = "1.10"

--- a/src/MUMPS.jl
+++ b/src/MUMPS.jl
@@ -39,6 +39,13 @@ if haskey(ENV, "JULIA_MUMPS_LIBRARY_PATH")
   const libcmumpspar = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libcmumps.$dlext")
   const libzmumpspar = joinpath(ENV["JULIA_MUMPS_LIBRARY_PATH"], "libzmumps.$dlext")
   const MUMPS_INSTALLATION = "CUSTOM"
+elseif haskey(ENV, "MUMPS_SEQ") || Sys.iswindows()
+  using MUMPS_seq_jll
+  const libsmumpspar = MUMPS_seq_jll.libsmumps
+  const libdmumpspar = MUMPS_seq_jll.libdmumps
+  const libcmumpspar = MUMPS_seq_jll.libcmumps
+  const libzmumpspar = MUMPS_seq_jll.libzmumps
+  const MUMPS_INSTALLATION = "YGGDRASIL"
 else
   using MUMPS_jll
   const MUMPS_INSTALLATION = "YGGDRASIL"

--- a/src/exported_methods.jl
+++ b/src/exported_methods.jl
@@ -201,7 +201,7 @@ function get_icntl(;
   if !verbose
     icntl[1:4] .= 0
   end
-  #icntl[22] = ooc ? 1 : 0
+  icntl[22] = ooc ? 1 : 0
   icntl[10] = itref
   icntl[7] = user_perm ? 1 : 7  # 1 = user-supplied, 7 = automatic
   return icntl

--- a/src/exported_methods.jl
+++ b/src/exported_methods.jl
@@ -201,7 +201,7 @@ function get_icntl(;
   if !verbose
     icntl[1:4] .= 0
   end
-  icntl[22] = ooc ? 1 : 0
+  #icntl[22] = ooc ? 1 : 0
   icntl[10] = itref
   icntl[7] = user_perm ? 1 : 7  # 1 = user-supplied, 7 = automatic
   return icntl

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -28,6 +28,8 @@ for (fname, lname, elty, subty) in (
     function invoke_mumps_unsafe!(mumps::Mumps{$elty, $subty})
       MPI.Initialized() ||
         throw(MUMPSException("must call MPI.Init() exactly once before calling mumps"))
+      (mumps.icntl[7] == 7 && mumps.icntl[22] > 0 && (haskey(ENV, "MUMPS_SEQ") || Sys.iswindows())) &&
+        @warn "MUMPS.jl: using the out-of-core storage (ICNTL[22] > 0), does not work well with MUMPS_seq_jll, we encourage to either deactivate or use MUMPS_jll."
       ccall(($fname, $lname), Cvoid, (Ref{Mumps{$elty, $subty}},), mumps)
       mumps.err = mumps.infog[1]
       return mumps

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -28,7 +28,7 @@ for (fname, lname, elty, subty) in (
     function invoke_mumps_unsafe!(mumps::Mumps{$elty, $subty})
       MPI.Initialized() ||
         throw(MUMPSException("must call MPI.Init() exactly once before calling mumps"))
-      (mumps.icntl[7] == 7 && mumps.icntl[22] > 0 && (haskey(ENV, "MUMPS_SEQ") || Sys.iswindows())) &&
+      (mumps.icntl[7] == 7 && mumps.icntl[22] > 0 && isdefined(@__MODULE__, :MUMPS_seq_jll)) &&
         @warn "MUMPS.jl: using the out-of-core storage (ICNTL[22] > 0), does not work well with MUMPS_seq_jll, we encourage to either deactivate or use MUMPS_jll."
       ccall(($fname, $lname), Cvoid, (Ref{Mumps{$elty, $subty}},), mumps)
       mumps.err = mumps.infog[1]

--- a/src/mumps_struc.jl
+++ b/src/mumps_struc.jl
@@ -113,7 +113,7 @@ mutable struct Mumps{TC, TR}
   pivnul_list::Ptr{MUMPS_INT}
   mapping::Ptr{MUMPS_INT}
   singular_values::Ptr{TR}
-  nb_singular_values::Cint
+  nb_singular_values::MUMPS_INT
 
   size_schur::MUMPS_INT
   listvar_schur::Ptr{MUMPS_INT}

--- a/src/mumps_struc.jl
+++ b/src/mumps_struc.jl
@@ -110,10 +110,10 @@ mutable struct Mumps{TC, TR}
   rinfo::NTuple{40, TR}
   rinfog::NTuple{40, TR}
 
-  deficiency::MUMPS_INT
   pivnul_list::Ptr{MUMPS_INT}
   mapping::Ptr{MUMPS_INT}
   singular_values::Ptr{TR}
+  nb_singular_values::Cint
 
   size_schur::MUMPS_INT
   listvar_schur::Ptr{MUMPS_INT}

--- a/test/mumps_test_float.jl
+++ b/test/mumps_test_float.jl
@@ -1,4 +1,4 @@
-icntl = get_icntl(det = true, ooc = true, itref = 1);
+icntl = get_icntl(det = true, itref = 1);
 tol = sqrt(eps(Float32))
 
 mumps1 = quiet_mumps(Float32; sym = mumps_definite)


### PR DESCRIPTION
Hi @amontoison, @dpo.

@amontoison, this is following our chat from friday. 
I started from #107 and am trying to solve the CI failures on Windows.

Right now, i discovered that the out of core option was causing issues when using `mumps_seq_jll`, i just commented it out for now. This makes the CI go farther but some errors are remaining, I open this as a draft to show you where I am after a very very very long debugging session.


Hopefully, this solves #110.